### PR TITLE
GitHub × Codex連携: CODEOWNERS と @codex メンション検知ワークフローを追加

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS
+# デフォルト: すべてのファイルのレビュー担当
+*                           @tomotto1296
+
+# メイン本体
+anima_pipeline.py           @tomotto1296
+
+# 設定・ワークフロー
+settings/                   @tomotto1296
+workflows/                  @tomotto1296
+
+# ドキュメント（レビュー任意）
+docs/                       @tomotto1296
+*.md                        @tomotto1296
+
+# GitHub 設定（要レビュー）
+.github/                    @tomotto1296

--- a/.github/workflows/codex-trigger.yml
+++ b/.github/workflows/codex-trigger.yml
@@ -1,0 +1,42 @@
+name: Codex Mention Trigger
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  handle-codex-mention:
+    if: |
+      contains(github.event.comment.body, '@codex') &&
+      github.event.comment.user.login != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Acknowledge mention
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.comment.body;
+            const isPR = !!context.payload.pull_request ||
+                         context.eventName === 'pull_request_review_comment';
+
+            const reactionTarget = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            };
+
+            // PRレビューコメントとIssueコメントで API が異なる
+            if (context.eventName === 'pull_request_review_comment') {
+              await github.rest.reactions.createForPullRequestReviewComment(reactionTarget);
+            } else {
+              await github.rest.reactions.createForIssueComment(reactionTarget);
+            }
+
+            console.log(`@codex mention detected:\n${body}`);


### PR DESCRIPTION
## Summary
- `.github/CODEOWNERS` を追加し、全ファイルのレビュー担当を `@tomotto1296` に設定
- `.github/workflows/codex-trigger.yml` を追加し、PR・Issueコメントの `@codex` メンションを検知して 👀 リアクションで応答

## Changes
- [x] ドキュメント更新
- [x] 機能追加（GitHub Actions ワークフロー）

## How to Verify
1. PRまたはIssueコメントに `@codex` を含むコメントを投稿
2. ワークフローが起動し、コメントに 👀 リアクションが付くことを確認

## Impact
- 影響範囲: `.github/` のみ（アプリ本体に変更なし）
- リスク: 低

## Checklist
- [x] 既存機能への影響なし
- [ ] codex.openai.com でGitHub Appのインストールが必要（別途作業）
